### PR TITLE
Update Travis to Test Current Go Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 script: go test -v
 
 go:
-  - 1.5
-  - 1.6
-  - 1.7
+  - "1.5.x"
+  - "1.13.x"
+  - "1.14.x"
+  - tip


### PR DESCRIPTION
Travis was configured to test against some older versions of Go, this updates `.travis.yml` to test against `1.13`, `1.14`, and the current development branch.